### PR TITLE
Made busy-indicator work within modules

### DIFF
--- a/busy-indicator/helpers.R
+++ b/busy-indicator/helpers.R
@@ -34,9 +34,16 @@ withBusyIndicatorUI <- function(button) {
 # expression to run when the button is clicked
 withBusyIndicatorServer <- function(buttonId, expr) {
   # UX stuff: show the "busy" message, hide the other messages, disable the button
-  loadingEl <- sprintf("[data-for-btn=%s] .btn-loading-indicator", buttonId)
-  doneEl <- sprintf("[data-for-btn=%s] .btn-done-indicator", buttonId)
-  errEl <- sprintf("[data-for-btn=%s] .btn-err", buttonId)
+  session <- shinyjs:::getSession()
+  if(inherits(session, "session_proxy")) {
+    loadingEl <- sprintf("[data-for-btn=%s] .btn-loading-indicator", session$ns(buttonId))
+    doneEl <- sprintf("[data-for-btn=%s] .btn-done-indicator", session$ns(buttonId))
+    errEl <- sprintf("[data-for-btn=%s] .btn-err", session$ns(buttonId))  
+  } else {
+    loadingEl <- sprintf("[data-for-btn=%s] .btn-loading-indicator", buttonId)
+    doneEl <- sprintf("[data-for-btn=%s] .btn-done-indicator", buttonId)
+    errEl <- sprintf("[data-for-btn=%s] .btn-err", buttonId)
+  }
   shinyjs::disable(buttonId)
   shinyjs::show(selector = loadingEl)
   shinyjs::hide(selector = doneEl)
@@ -59,8 +66,14 @@ withBusyIndicatorServer <- function(buttonId, expr) {
 
 # When an error happens after a button click, show the error
 errorFunc <- function(err, buttonId) {
-  errEl <- sprintf("[data-for-btn=%s] .btn-err", buttonId)
-  errElMsg <- sprintf("[data-for-btn=%s] .btn-err-msg", buttonId)
+  session <- shinyjs:::getSession()
+  if(inherits(session, "session_proxy")) {
+    errEl <- sprintf("[data-for-btn=%s] .btn-err", session$ns(buttonId))
+    errElMsg <- sprintf("[data-for-btn=%s] .btn-err-msg", session$ns(buttonId))
+  } else {
+    errEl <- sprintf("[data-for-btn=%s] .btn-err", buttonId)
+    errElMsg <- sprintf("[data-for-btn=%s] .btn-err-msg", buttonId)
+  }
   errMessage <- gsub("^ddpcr: (.*)", "\\1", err$message)
   shinyjs::html(html = errMessage, selector = errElMsg)
   shinyjs::show(selector = errEl, anim = TRUE, animType = "fade")


### PR DESCRIPTION
Made busy-indicator work within modules, requires git version of shinyjs https://github.com/daattali/shinyjs/commit/8627e85f61f3535ea85f9409c7a86246daa2a203